### PR TITLE
Fa guard hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.3.0
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 && \
     chmod +x /usr/local/bin/dumb-init
 
-RUN gem install publish_to_web --version 2.2.1 --no-rdoc --no-ri
+RUN gem install publish_to_web --version 2.2.2 --no-rdoc --no-ri
 
 COPY start_publish_to_web /bin/start_publish_to_web
 RUN chmod 755 /bin/start_publish_to_web

--- a/start_publish_to_web
+++ b/start_publish_to_web
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
-require 'publish_to_web'
+
 # Make sure to flush logs immediately
 STDOUT.sync = STDERR.sync = true
+
+require 'publish_to_web'
 
 def gateway
   # /proc/net/route contains all infos about current routes, we extract the default Gateway
@@ -18,10 +20,13 @@ if ENV['DEBUG']
 end
 
 PublishToWeb.new(bind_host: gateway).tap do |ptw|
+
   if ENV['DEBUG'] and ENV['LICENSE_KEY']
     puts "Using license key given from ENV for debugging"
     ptw.config.license_key = ENV['LICENSE_KEY']
   end
 
+  trap :SIGUSR1 { ptw.prepare_directory }
   ptw.start_tunnel
+
 end


### PR DESCRIPTION
Requires https://github.com/protonet/publish_to_web/pull/1 being pulled in first.
